### PR TITLE
Adds dummy Android file to allow import

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -1,0 +1,4 @@
+export default {
+  addEventListener: callback => {},
+  removeEventListener: () => {}
+}


### PR DESCRIPTION
This is an issue because conditional imports are not possible in ES6, so it's necessary to maintain separate files for Android and iOS (`file.android.js` and `file.ios.js`) or check `Platform.OS` before each method call. This simple dummy file allows you to treat the import like any other.

Let me know if this makes sense! Thanks so much for your work on this.